### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-terminal"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "portable-pty",
  "schemars",

--- a/shadow-terminal-cli/CHANGELOG.md
+++ b/shadow-terminal-cli/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/tattoy-org/shadow-terminal/releases/tag/shadow-terminal-cli-v0.1.0) - 2025-07-02
+
+### Added
+
+- adds `shadow-terminal` CLI binary
+
+### Other
+
+- add binary build and release workflow
+- first commit as repo outside of Tattoy

--- a/shadow-terminal-cli/Cargo.toml
+++ b/shadow-terminal-cli/Cargo.toml
@@ -25,7 +25,7 @@ color-eyre = "0.6.5"
 clap = { version = "4.5.40", features = ["derive", "env"] }
 
 [dependencies.shadow-terminal]
-version = "0.1.1"
+version = "0.2.0"
 path = "../shadow-terminal"
 
 [lints]

--- a/shadow-terminal/CHANGELOG.md
+++ b/shadow-terminal/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-v0.1.1...shadow-terminal-v0.2.0) - 2025-07-02
+
+### Added
+
+- adds `shadow-terminal` CLI binary
+
+### Other
+
+- add binary build and release workflow
+- first commit as repo outside of Tattoy

--- a/shadow-terminal/Cargo.toml
+++ b/shadow-terminal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shadow-terminal"
 description = "A headless modern terminal emulator"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/tattoy-org/shadow-terminal"


### PR DESCRIPTION



## 🤖 New release

* `shadow-terminal`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `shadow-terminal-cli`: 0.1.0

### ⚠ `shadow-terminal` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum shadow_terminal::output::SurfaceDiff, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:48
  enum shadow_terminal::output::ScreenMode, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:36
  enum shadow_terminal::output::SurfaceKind, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:180
  enum shadow_terminal::output::Output, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:169
  enum shadow_terminal::output::CompleteSurface, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:119

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function shadow_terminal::output::raw_string_direct_to_terminal, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:19

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct shadow_terminal::output::CompleteScrollback, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:149
  struct shadow_terminal::output::CompleteScreen, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:159
  struct shadow_terminal::output::ScrollbackDiff, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:63
  struct shadow_terminal::output::ScreenDiff, previously in file /tmp/.tmp4JucHx/shadow-terminal/src/output.rs:83
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `shadow-terminal`

<blockquote>

## [0.2.0](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-v0.1.1...shadow-terminal-v0.2.0) - 2025-07-02

### Added

- adds `shadow-terminal` CLI binary

### Other

- add binary build and release workflow
- first commit as repo outside of Tattoy
</blockquote>

## `shadow-terminal-cli`

<blockquote>

## [0.1.0](https://github.com/tattoy-org/shadow-terminal/releases/tag/shadow-terminal-cli-v0.1.0) - 2025-07-02

### Added

- adds `shadow-terminal` CLI binary

### Other

- add binary build and release workflow
- first commit as repo outside of Tattoy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).