### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-terminal"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "portable-pty",
  "schemars",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-terminal-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/shadow-terminal-cli/CHANGELOG.md
+++ b/shadow-terminal-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-cli-v0.1.0...shadow-terminal-cli-v0.1.1) - 2025-07-21
+
+### Other
+
+- v0.2.1
+
 ## [0.1.0](https://github.com/tattoy-org/shadow-terminal/releases/tag/shadow-terminal-cli-v0.1.0) - 2025-07-02
 
 ### Added

--- a/shadow-terminal-cli/Cargo.toml
+++ b/shadow-terminal-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shadow-terminal-cli"
 description = "A headless modern terminal emulator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/tattoy-org/shadow-terminal"
@@ -25,7 +25,7 @@ color-eyre = "0.6.5"
 clap = { version = "4.5.40", features = ["derive", "env"] }
 
 [dependencies.shadow-terminal]
-version = "0.2.0"
+version = "0.2.2"
 path = "../shadow-terminal"
 
 [lints]

--- a/shadow-terminal/CHANGELOG.md
+++ b/shadow-terminal/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-v0.2.1...shadow-terminal-v0.2.2) - 2025-07-21
+
+### Fixed
+
+- count chars not len in `wait_for_string_at`
+
+### Other
+
+- v0.2.1
+
 ## [0.2.0](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-v0.1.1...shadow-terminal-v0.2.0) - 2025-07-02
 
 ### Added

--- a/shadow-terminal/Cargo.toml
+++ b/shadow-terminal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shadow-terminal"
 description = "A headless modern terminal emulator"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/tattoy-org/shadow-terminal"


### PR DESCRIPTION



## 🤖 New release

* `shadow-terminal`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `shadow-terminal-cli`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `shadow-terminal`

<blockquote>

## [0.2.2](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-v0.2.1...shadow-terminal-v0.2.2) - 2025-07-21

### Fixed

- count chars not len in `wait_for_string_at`

### Other

- v0.2.1
</blockquote>

## `shadow-terminal-cli`

<blockquote>

## [0.1.1](https://github.com/tattoy-org/shadow-terminal/compare/shadow-terminal-cli-v0.1.0...shadow-terminal-cli-v0.1.1) - 2025-07-21

### Other

- v0.2.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).