### PR TITLE
feat: refactor `send-command` into 2 functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-terminal"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "portable-pty",
  "schemars",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "shadow-terminal-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/shadow-terminal-cli/Cargo.toml
+++ b/shadow-terminal-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shadow-terminal-cli"
 description = "A headless modern terminal emulator"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/tattoy-org/shadow-terminal"
@@ -25,7 +25,7 @@ color-eyre = "0.6.5"
 clap = { version = "4.5.40", features = ["derive", "env"] }
 
 [dependencies.shadow-terminal]
-version = "0.2.2"
+version = "0.2.3"
 path = "../shadow-terminal"
 
 [lints]

--- a/shadow-terminal/Cargo.toml
+++ b/shadow-terminal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shadow-terminal"
 description = "A headless modern terminal emulator"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/tattoy-org/shadow-terminal"

--- a/shadow-terminal/src/pty.rs
+++ b/shadow-terminal/src/pty.rs
@@ -337,7 +337,9 @@ impl PTY {
     ) -> Result<(), crate::errors::PTYError> {
         tracing::trace!(
             "Forwarding input to PTY: '{}'",
-            String::from_utf8_lossy(&bytes).replace('\n', "\\n")
+            String::from_utf8_lossy(&bytes)
+                .replace('\n', "\\n")
+                .replace('\x1b', "^")
         );
 
         let maybe_size = bytes.iter().position(|byte| byte == &0);

--- a/shadow-terminal/src/steppable_terminal.rs
+++ b/shadow-terminal/src/steppable_terminal.rs
@@ -180,6 +180,30 @@ impl SteppableTerminal {
     /// If sending the string fails
     #[inline]
     pub fn send_command(&self, command: &str) -> Result<(), crate::errors::PTYError> {
+        self.send_input(Input::Characters(format!("{command}\n")))?;
+
+        Ok(())
+    }
+
+    /// Send a command using an OSC paste event.
+    ///
+    /// This is generally the preferred way to send commands. It's just more efficient then sending
+    /// each character separately. However, for some reason, that I haven't been able to get to the
+    /// bottom of, some PTY processes parse out the OSC paste ANSI codes and some don't. I didn't
+    /// even know that PTY's had anything to do with parsing ANSI, so I could well be mistaken and
+    /// would appreciate being corrected.
+    ///
+    /// So if you have problems with this function then just use `send_command()` instead.
+    ///
+    /// @tombh July 2025.
+    ///
+    /// # Errors
+    /// If sending the string fails
+    #[inline]
+    pub fn send_command_with_osc_paste(
+        &self,
+        command: &str,
+    ) -> Result<(), crate::errors::PTYError> {
         self.paste_string(command)?;
         self.send_input(Input::Characters("\n".to_owned()))?;
 
@@ -432,6 +456,8 @@ impl SteppableTerminal {
             }
             tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
         }
+
+        self.dump_screen()?;
 
         Ok(())
     }


### PR DESCRIPTION
The old `send_command` now just sends all the characters of the command individually. And so there's a new command,
`send_command_with_osc_paste()` that retains the old behaviour.

This should fix a lot of the tests failing inside Nix.

Relates to https://github.com/tattoy-org/tattoy/pull/104.